### PR TITLE
Enable Audio Calling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #Web Skype Electron Wrapper
 
-##Please note: This application is ONLY for text chat. Voice and video calls are not supported.
+##Please note: This application is only for text and voice chat. Video calls are not supported and *will* cause a crash.
 
 The Skype desktop app is awful on most platforms, but their web client is fantastic. Let's put one inside the other.
 
@@ -9,7 +9,8 @@ In addition to a better Skype text client, ElectroSkype supports custom styleshe
 ## Known Issues
 - Notifications
 -- Notification popup windows/toast notifications don't work, and may never be implemented. Sounds do still work, however.
-- Voice and video calls are not supported, due to their reliance on a signed browser plugin.
+- Video calls are not supported due to their reliance on a signed browser plugin.
+- Voice calls only work if you initiate the call. Otherwise it will prompt you to install a plugin.
 - Older P2P group chats are not supported by the web client, and will not show up in the contacts list. Newer group chats work just fine. (Log into [the web client](https://web.skype.com) in your browser to check any of your existing groups)
 
 ---

--- a/app/index.html
+++ b/app/index.html
@@ -19,6 +19,6 @@
 		</ul>
 	</div>
 
-	<webview id="skype-webview" src="https://web.skype.com/" allowpopups style="overflow: hidden; width:100%; height:100%;"></webview>
+	<webview id="skype-webview" src="data:text/html,<h4>Skype Loading</h4>" allowpopups style="overflow: hidden; width:100%; height:100%;"></webview>
 </body>
 </html>

--- a/app/js/preloadInit.js
+++ b/app/js/preloadInit.js
@@ -16,8 +16,21 @@
 		console.log("set data");
 	});
 
+	prepareWebView = function() {
+		var webView = document.getElementById("skype-webview");
+		webView.removeEventListener('dom-ready', prepareWebView);
+
+		webView.loadURL('https://web.skype.com', {
+			// Fake user agent to Edge to enable audio calling. Video calling is not functional.
+			userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10586'
+		});
+	}
+
 	window.electronWindowSetup = function() {
 		var webView = document.getElementById("skype-webview");
+		webView.addEventListener('dom-ready', prepareWebView);
+
+
 		webView.addEventListener('did-stop-loading', function(event) {
 			webView.insertCSS(window.cssData);
 		});


### PR DESCRIPTION
This PR sets the user agent to mimic Microsoft Edge 13, causing the Skype Web application to enable audio calling, which works flawlessly if you initiate the call. (If someone else calls you, you will be prompted to install a plugin.)
Video calling does not work properly and will crash. Noted in readme.

Nice work by the way, the custom stylesheet is a nice touch. :)
